### PR TITLE
feat: [n8n-583] add BADGES_ACCREDIBLE_API_BASE_URL config variable

### DIFF
--- a/tutorbadges/patches/credentials-settings-production
+++ b/tutorbadges/patches/credentials-settings-production
@@ -1,2 +1,3 @@
 BADGES_CONFIG['credly']['USE_SANDBOX'] = {% if BADGES_CREDLY_USE_SANDBOX %}True{% else %}False{% endif %}
 BADGES_CONFIG['accredible']['USE_SANDBOX'] = {% if BADGES_ACCREDIBLE_USE_SANDBOX %}True{% else %}False{% endif %}
+BADGES_CONFIG['accredible']['ACCREDIBLE_API_BASE_URL'] = '{{ BADGES_ACCREDIBLE_API_BASE_URL }}'

--- a/tutorbadges/plugin.py
+++ b/tutorbadges/plugin.py
@@ -39,6 +39,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("BADGES_VERSION", __version__),
         ("BADGES_CREDLY_USE_SANDBOX", False),
         ("BADGES_ACCREDIBLE_USE_SANDBOX", False),
+        ("BADGES_ACCREDIBLE_API_BASE_URL", "https://api.accredible.com/v1/"),
         ("BADGES_DEBUG", False),
         # Event Bus settings
         ("EVENT_BUS_BACKEND", EVENT_BUS_BACKEND_REDIS),


### PR DESCRIPTION
## What

- Add `BADGES_ACCREDIBLE_API_BASE_URL` to `CONFIG_DEFAULTS` with US endpoint as default
- Apply the variable in `credentials-settings-production` patch so deployments can override it

## Why

The Accredible API base URL is currently hardcoded. Deployments using EU-region Accredible accounts receive 401 Unauthorized errors because the US endpoint rejects their API keys. Making the URL configurable allows each deployment to set the correct regional endpoint.

## Related MRs

- `tutor-deployment` — [!26](https://gitlab.raccoongang.com/kraken/n8n/tutor-deployment/-/merge_requests/26) — configure Accredible EU API endpoint

## Ticket

- [n8n-583](https://youtrack.raccoongang.com/issue/n8n-583) — Accredible EU API endpoint support for Badges

## Test plan

- [ ] Deploy with `TUTOR_BADGES_ACCREDIBLE_API_BASE_URL` set to EU endpoint and verify Accredible API connection returns 200 in the Badges admin